### PR TITLE
Fix ordinal node syncing

### DIFF
--- a/deployment/charts/bitcoind/templates/configmap.yaml
+++ b/deployment/charts/bitcoind/templates/configmap.yaml
@@ -8,7 +8,6 @@ data:
     mainnet=1
     signet=0
     txindex=1
-    disablewallet=1
 
     rpcport={{ .Values.bitcoind.rpcPort }}
     server=1

--- a/deployment/charts/laos-btc/templates/laos-btc-statefulset.yaml
+++ b/deployment/charts/laos-btc/templates/laos-btc-statefulset.yaml
@@ -24,6 +24,7 @@ spec:
         args:
           - --data-dir
           - /data
+          - --index-runes
           - --bitcoin-rpc-url
           - http://bitcoind:{{ .Values.bitcoind.rpcPort }}
           - --bitcoin-rpc-username


### PR DESCRIPTION
- include `-- index-runes` param when running ordinal server
- remove `disablewallet=1` option from bitcoind config; (see https://docs.ordinals.com/guides/wallet.html?highlight=disablewallet#troubleshooting)