### PR TITLE
add api for ask collection

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -1099,6 +1099,17 @@ impl Index {
 		Ok((entries, more))
 	}
 
+	pub fn get_brc721_collection_by_id(
+		&self,
+		collection_id: Brc721CollectionId,
+	) -> Result<Option<(H160, bool)>> {
+		if !self.brc721_collection_exists(collection_id)? {
+			return Ok(None);
+		}
+
+		Ok(Some((H160::default(), true)))
+	}
+
 	pub fn block_header(&self, hash: BlockHash) -> Result<Option<Header>> {
 		self.client.get_block_header(&hash).into_option()
 	}
@@ -1478,6 +1489,15 @@ impl Index {
 			.begin_read()?
 			.open_table(INSCRIPTION_ID_TO_SEQUENCE_NUMBER)?
 			.get(&inscription_id.store())?
+			.is_some())
+	}
+
+	pub fn brc721_collection_exists(&self, collection_id: Brc721CollectionId) -> Result<bool> {
+		Ok(self
+			.database
+			.begin_read()?
+			.open_table(BRC721_COLLECTION_ID_TO_BRC721_COLLECTION_VALUE)?
+			.get(&collection_id.store())?
 			.is_some())
 	}
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -1102,7 +1102,7 @@ impl Index {
 	pub fn get_brc721_collection_by_id(
 		&self,
 		collection_id: Brc721CollectionId,
-	) -> Result<Option<(H160, bool)>> {
+	) -> Result<Option<(Brc721CollectionId, H160, bool)>> {
 		let result = self
 			.database
 			.begin_read()?
@@ -1112,7 +1112,7 @@ impl Index {
 		// Convert the AccessGuard to the expected tuple type
 		let converted_result = result.map(|guard| {
 			let (address, flag) = guard.value();
-			(H160::from_slice(&address), flag)
+			(collection_id, H160::from_slice(&address), flag)
 		});
 
 		Ok(converted_result)

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -1898,7 +1898,7 @@ impl Server {
 		Extension(_index): Extension<Arc<Index>>,
 		_accept_json: AcceptJson,
 	) -> ServerResult {
-		unimplemented!();
+		Err(ServerError::NotFound("brc721 collection not found".to_string()))
 	}
 
 	async fn inscriptions_paginated(
@@ -7033,6 +7033,18 @@ next
 			"/brc721/collections",
 			StatusCode::BAD_REQUEST,
 			"this server has no brc721 index",
+		);
+	}
+
+	#[test]
+	fn brc721_collection_not_found() {
+		let server = TestServer::builder().chain(Chain::Regtest).index_brc721().build();
+
+		// Try to fetch a collection that does not exist
+		server.assert_response(
+			"/brc721/collection/impossible",
+			StatusCode::NOT_FOUND,
+			"brc721 collection not found",
 		);
 	}
 }

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -7095,6 +7095,10 @@ next
 
 		server.mine_blocks(1);
 
-		server.assert_response("/brc721/collection/2:1", StatusCode::OK, "\"ciao\"");
+		server.assert_response(
+			"/brc721/collection/2:1",
+			StatusCode::OK,
+			r#"{"id":"2:1","owner":"0x0000000000000000000000000000000000000000","rebaseable":true}"#,
+		);
 	}
 }

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -259,6 +259,7 @@ impl Server {
 				.route("/decode/:txid", get(Self::decode))
 				.route("/update", get(Self::update))
 				.route("/brc721/collections", get(Self::brc721_collections))
+				.route("/brc721/collection/:collection_id", get(Self::brc721_collection))
 				.fallback(Self::fallback)
 				.layer(Extension(index))
 				.layer(Extension(server_config.clone()))
@@ -1890,6 +1891,14 @@ impl Server {
 					.into_response()
 			})
 		})
+	}
+
+	async fn brc721_collection(
+		Extension(_server_config): Extension<Arc<ServerConfig>>,
+		Extension(_index): Extension<Arc<Index>>,
+		_accept_json: AcceptJson,
+	) -> ServerResult {
+		unimplemented!();
 	}
 
 	async fn inscriptions_paginated(

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -7082,7 +7082,8 @@ next
 		server.mine_blocks(1);
 
 		let address = H160::from_str("0xabcffffffffffffffffffffffffffffffffffcba").unwrap();
-		let rc = RegisterCollection { address, ..Default::default() };
+		let rebaseable = false;
+		let rc = RegisterCollection { address, rebaseable };
 
 		let _ = server.core.broadcast_tx(TransactionTemplate {
 			inputs: &[],
@@ -7098,7 +7099,7 @@ next
 		server.assert_response(
 			"/brc721/collection/2:1",
 			StatusCode::OK,
-			r#"{"id":"2:1","owner":"0x0000000000000000000000000000000000000000","rebaseable":true}"#,
+			r#"{"id":"2:1","owner":"0xabcffffffffffffffffffffffffffffffffffcba","rebaseable":false}"#,
 		);
 	}
 }

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -1906,9 +1906,9 @@ impl Server {
 
 		// Construct the JSON response with the collection details.
 		let response_data = serde_json::json!({
-			"id": collection_id,       // The ID of the collection.
-			"owner": data.0,           // The owner of the collection.
-			"rebaseable": data.1,      // Whether the collection is rebaseable.
+			"id": data.0,       // The ID of the collection.
+			"owner": data.1,           // The owner of the collection.
+			"rebaseable": data.2,      // Whether the collection is rebaseable.
 		});
 
 		// Return the JSON response as an HTTP response.

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -1896,9 +1896,10 @@ impl Server {
 	async fn brc721_collection(
 		Extension(_server_config): Extension<Arc<ServerConfig>>,
 		Extension(_index): Extension<Arc<Index>>,
+		Path(_collection_id): Path<Brc721CollectionId>,
 		_accept_json: AcceptJson,
 	) -> ServerResult {
-		Err(ServerError::NotFound("brc721 collection not found".to_string()))
+		Err(ServerError::NotFound("unexistent collection".to_string()))
 	}
 
 	async fn inscriptions_paginated(
@@ -7037,14 +7038,26 @@ next
 	}
 
 	#[test]
+	fn brc721_collection_bad_request() {
+		let server = TestServer::builder().chain(Chain::Regtest).index_brc721().build();
+
+		// Try to fetch a collection with malformed or invalid parameter
+		server.assert_response(
+			"/brc721/collection/impossible",
+			StatusCode::BAD_REQUEST,
+			"Invalid URL: missing separator",
+		);
+	}
+
+	#[test]
 	fn brc721_collection_not_found() {
 		let server = TestServer::builder().chain(Chain::Regtest).index_brc721().build();
 
 		// Try to fetch a collection that does not exist
 		server.assert_response(
-			"/brc721/collection/impossible",
+			"/brc721/collection/1020:1",
 			StatusCode::NOT_FOUND,
-			"brc721 collection not found",
+			"unexistent collection",
 		);
 	}
 }

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -1907,7 +1907,7 @@ impl Server {
 		// Construct the JSON response with the collection details.
 		let response_data = serde_json::json!({
 			"id": data.0,       // The ID of the collection.
-			"owner": data.1,           // The owner of the collection.
+			"LAOS_address": data.1,           // The address of the collection in LAOS.
 			"rebaseable": data.2,      // Whether the collection is rebaseable.
 		});
 
@@ -7099,7 +7099,7 @@ next
 		server.assert_response(
 			"/brc721/collection/2:1",
 			StatusCode::OK,
-			r#"{"id":"2:1","owner":"0xabcffffffffffffffffffffffffffffffffffcba","rebaseable":false}"#,
+			r#"{"id":"2:1","LAOS_address":"0xabcffffffffffffffffffffffffffffffffffcba","rebaseable":false}"#,
 		);
 	}
 }


### PR DESCRIPTION
This PR introduces the following changes:

1. **New Method: `get_brc721_collection_by_id`**
   - Added a new method `get_brc721_collection_by_id` to the `Index` struct.
   - This method retrieves a BRC721 collection by its ID and returns a tuple containing the owner's address (`H160`) and a boolean indicating if the collection is rebaseable.
   - If the collection does not exist, it returns `None`.

2. **New Route: `/brc721/collection/:collection_id`**
   - Added a new route `/brc721/collection/:collection_id` to the server.
   - This route handles GET requests to fetch details of a specific BRC721 collection by its ID.
   - If the collection does not exist, it returns a `404 Not Found` error.
   - If the collection exists, it returns a JSON response containing the collection ID, owner address, and rebaseable status.

3. **Unit Tests:**
   - Added unit tests for the new `/brc721/collection/:collection_id` route:
     - `brc721_collection_bad_request`: Tests the handling of a malformed or invalid collection ID.
     - `brc721_collection_not_found`: Tests the handling of a request for a non-existent collection.
     - `brc721_collection_found`: Tests the successful retrieval of a BRC721 collection.

These changes enhance the functionality of the BRC721 index by allowing the server to query and return details about specific BRC721 collections.