### PR TITLE
feat: Address Mapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3380,6 +3380,7 @@ name = "ordinals"
 version = "0.0.14"
 dependencies = [
  "bitcoin",
+ "bitcoin_hashes 0.14.0",
  "derive_more",
  "hex",
  "pretty_assertions",

--- a/crates/ordinals/Cargo.toml
+++ b/crates/ordinals/Cargo.toml
@@ -10,6 +10,7 @@ rust-version = "1.74.0"
 
 [dependencies]
 bitcoin = { version = "0.32.5", features = ["rand"] }
+bitcoin_hashes = "0.14.0"
 derive_more = { version = "1.0.0", features = ["display", "from_str"] }
 serde = { version = "1.0.137", features = ["derive"] }
 serde_with = "3.7.0"

--- a/crates/ordinals/src/brc721.rs
+++ b/crates/ordinals/src/brc721.rs
@@ -1,3 +1,4 @@
+pub mod address_mapping;
 pub mod collection_id;
 pub mod register_collection;
 

--- a/crates/ordinals/src/brc721/address_mapping.rs
+++ b/crates/ordinals/src/brc721/address_mapping.rs
@@ -14,8 +14,7 @@ pub enum AddressMappingError {
 pub fn btc_address_to_h160(address: Address) -> Result<H160, AddressMappingError> {
 	if let Some(program) = address.witness_program() {
 		if program.is_p2wpkh() {
-			let h160_bytes: Vec<u8> =
-				program.program().as_bytes().iter().map(|&byte| byte).collect();
+			let h160_bytes: Vec<u8> = program.program().as_bytes().to_vec();
 			return Ok(H160::from_slice(&h160_bytes));
 		}
 	} else {

--- a/crates/ordinals/src/brc721/address_mapping.rs
+++ b/crates/ordinals/src/brc721/address_mapping.rs
@@ -1,0 +1,116 @@
+use bitcoin::{Address, Network, WitnessProgram, WitnessVersion};
+use bitcoin_hashes::{hash160::Hash as BTCH160, Hash};
+use sp_core::H160;
+use thiserror::Error;
+
+/// Custom error type for errors related to the address mapping.
+#[derive(Debug, Error, PartialEq)]
+pub enum AddressMappingError {
+	/// Invalid address error
+	#[error("Invalid BTC address: `{0}`. Only P2PKH and P2WPKH supported.")]
+	InvalidAddress(Address),
+}
+
+pub fn btc_address_to_h160(address: Address) -> Result<H160, AddressMappingError> {
+	if let Some(program) = address.witness_program() {
+		if program.is_p2wpkh() {
+			let h160_bytes: Vec<u8> =
+				program.program().as_bytes().into_iter().map(|&byte| byte).collect();
+			return Ok(H160::from_slice(&h160_bytes));
+		}
+	} else {
+		let script_pubkey = address.script_pubkey();
+		let script_bytes = script_pubkey.as_bytes();
+
+		if script_bytes.len() == 25 && script_bytes[0] == 0x76  // OP_DUP
+            && script_bytes[1] == 0xa9  // OP_HASH160
+            && script_bytes[2] == 0x14  // H160 length (20 bytes)
+            && script_bytes[23] == 0x88 // OP_EQUALVERIFY
+            && script_bytes[24] == 0xac
+		// OP_CHECKSIG
+		{
+			return Ok(H160::from_slice(&script_bytes[3..23]));
+		}
+	}
+
+	Err(AddressMappingError::InvalidAddress(address))
+}
+
+pub fn h160_to_btc_address(
+	h160: H160,
+	network: Network,
+	is_segwit: bool,
+) -> Result<Address, AddressMappingError> {
+	let bytes = h160.as_bytes();
+
+	if is_segwit {
+		// P2WPKH address
+		let program = WitnessProgram::new(WitnessVersion::V0, bytes)
+			.expect("H160 contains exactly 20 bytes; qed;");
+		Ok(Address::from_witness_program(program, network))
+	} else {
+		// P2PKH address
+		let hash: BTCH160 =
+			BTCH160::from_slice(bytes).expect("H160 contains exactly 20 bytes; qed;");
+		Ok(Address::p2pkh(hash, network))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use bitcoin::Network;
+	use std::str::FromStr;
+
+	#[test]
+	fn test_p2wpkh_conversion() {
+		let addr_str = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4";
+		let address =
+			Address::from_str(addr_str).unwrap().require_network(Network::Bitcoin).unwrap();
+
+		let expected_h160 =
+			H160::from_slice(&hex::decode("751e76e8199196d454941c45d1b3a323f1433bd6").unwrap());
+
+		let h160 = btc_address_to_h160(address.clone())
+			.expect("Valid P2WPKH address should be mapped correctly");
+		assert_eq!(h160, expected_h160);
+
+		let back_address = h160_to_btc_address(h160, Network::Bitcoin, true)
+			.expect("Valid H160 should be mapped back to P2WPKH");
+		assert_eq!(address, back_address);
+	}
+
+	#[test]
+	fn test_p2pkh_conversion() {
+		let addr_str = "1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH";
+		let address =
+			Address::from_str(addr_str).unwrap().require_network(Network::Bitcoin).unwrap();
+
+		let expected_h160 =
+			H160::from_slice(&hex::decode("751e76e8199196d454941c45d1b3a323f1433bd6").unwrap());
+
+		let h160 = btc_address_to_h160(address.clone())
+			.expect("Valid P2PKH address should be mapped correctly");
+		assert_eq!(h160, expected_h160);
+
+		let back_address = h160_to_btc_address(h160, Network::Bitcoin, false)
+			.expect("Valid H160 should be mapped back to P2PKH");
+		assert_eq!(address, back_address);
+	}
+
+	#[test]
+	fn test_invalid_address_error() {
+		// This is a typical P2SH address which is not supported by our conversion functions.
+		let addr_str = "3QJmV3qfvL9SuYo34YihAf3sRCW3qSinyC";
+		let address =
+			Address::from_str(addr_str).unwrap().require_network(Network::Bitcoin).unwrap();
+
+		let result = btc_address_to_h160(address.clone());
+		match result {
+			Err(AddressMappingError::InvalidAddress(addr)) => {
+				assert_eq!(addr, address);
+			},
+			_ => panic!("Expected InvalidAddress error variant"),
+		}
+	}
+}

--- a/crates/ordinals/src/brc721/address_mapping.rs
+++ b/crates/ordinals/src/brc721/address_mapping.rs
@@ -15,7 +15,7 @@ pub fn btc_address_to_h160(address: Address) -> Result<H160, AddressMappingError
 	if let Some(program) = address.witness_program() {
 		if program.is_p2wpkh() {
 			let h160_bytes: Vec<u8> =
-				program.program().as_bytes().into_iter().map(|&byte| byte).collect();
+				program.program().as_bytes().iter().map(|&byte| byte).collect();
 			return Ok(H160::from_slice(&h160_bytes));
 		}
 	} else {


### PR DESCRIPTION
Add the address mapping following the paper specs, so we can identify a `H160` address with P2PKH/P2PWKH scripts in bitcoin