### PR TITLE
feat: add brc721 operations bytes to identify brc721 operations

### DIFF
--- a/crates/ordinals/src/brc721.rs
+++ b/crates/ordinals/src/brc721.rs
@@ -1,6 +1,7 @@
 pub mod address_mapping;
 pub mod collection;
 pub mod collection_id;
+pub(crate) mod flags;
 pub mod register_collection;
 
 use super::*;

--- a/crates/ordinals/src/brc721.rs
+++ b/crates/ordinals/src/brc721.rs
@@ -1,7 +1,7 @@
 pub mod address_mapping;
 pub mod collection;
 pub mod collection_id;
-pub(crate) mod flags;
+pub(crate) mod operations;
 pub mod register_collection;
 
 use super::*;

--- a/crates/ordinals/src/brc721/flags.rs
+++ b/crates/ordinals/src/brc721/flags.rs
@@ -7,14 +7,14 @@ pub(crate) const BRC721_INIT_CODE: opcodes::Opcode = opcodes::all::OP_PUSHNUM_15
 /// numerical byte of each operation. Only fieldless variants are allowed, leading to a compile
 /// error otherwise.
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) enum Brc721Flag {
+pub(crate) enum Brc721Operation {
 	RegisterCollection,
 	// TODO: Remove this attribute as soon as register ownership flow is introduced
 	#[allow(dead_code)]
 	RegisterOwnership,
 }
 
-impl Brc721Flag {
+impl Brc721Operation {
 	pub(crate) fn byte_slice(self) -> [u8; BRC721_FLAG_LENGTH] {
 		[self as u8]
 	}

--- a/crates/ordinals/src/brc721/flags.rs
+++ b/crates/ordinals/src/brc721/flags.rs
@@ -15,7 +15,7 @@ pub(crate) enum Brc721Flag {
 }
 
 impl Brc721Flag {
-	pub(crate) fn byte_slice(self) -> [u8; 1] {
+	pub(crate) fn byte_slice(self) -> [u8; BRC721_FLAG_LENGTH] {
 		[self as u8]
 	}
 }

--- a/crates/ordinals/src/brc721/flags.rs
+++ b/crates/ordinals/src/brc721/flags.rs
@@ -3,7 +3,7 @@ use bitcoin::opcodes;
 /// The opcode used to identify register collection operations.
 pub(crate) const BRC721_INIT_CODE: opcodes::Opcode = opcodes::all::OP_PUSHNUM_15;
 
-/// Byte flag to identify which mode of brc721 is used. Just a fancy name to don't remember the
+/// Byte to identify which operation of brc721 is used. Just a fancy name to don't remember the
 /// numerical byte of each operation. Only fieldless variants are allowed, leading to a compile
 /// error otherwise.
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/ordinals/src/brc721/flags.rs
+++ b/crates/ordinals/src/brc721/flags.rs
@@ -21,4 +21,4 @@ impl Brc721Operation {
 }
 
 /// The size of a brc721 flag in bytes
-pub(crate) const BRC721_FLAG_LENGTH: usize = 1;
+pub(crate) const BRC721_OPERATION_LENGTH: usize = 1;

--- a/crates/ordinals/src/brc721/flags.rs
+++ b/crates/ordinals/src/brc721/flags.rs
@@ -13,7 +13,7 @@ pub(crate) enum Brc721Flag {
 }
 
 impl Brc721Flag {
-	pub(crate) fn to_byte_slice(self) -> [u8; 1] {
+	pub(crate) fn byte_slice(self) -> [u8; 1] {
 		[self as u8]
 	}
 }

--- a/crates/ordinals/src/brc721/flags.rs
+++ b/crates/ordinals/src/brc721/flags.rs
@@ -9,7 +9,9 @@ pub(crate) const BRC721_INIT_CODE: opcodes::Opcode = opcodes::all::OP_PUSHNUM_15
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum Brc721Flag {
 	RegisterCollection,
-	//RegisterOwnership,
+	// TODO: Remove this attribute as soon as register ownership flow is introduced
+	#[allow(dead_code)]
+	RegisterOwnership,
 }
 
 impl Brc721Flag {

--- a/crates/ordinals/src/brc721/flags.rs
+++ b/crates/ordinals/src/brc721/flags.rs
@@ -1,0 +1,22 @@
+use bitcoin::opcodes;
+
+/// The opcode used to identify register collection operations.
+pub(crate) const BRC721_INIT_CODE: opcodes::Opcode = opcodes::all::OP_PUSHNUM_15;
+
+/// Byte flag to identify which mode of brc721 is used. Just a fancy name to don't remember the
+/// numerical byte of each operation. Only fieldless variants are allowed, leading to a compile
+/// error otherwise.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum Brc721Flag {
+	RegisterCollection,
+	//RegisterOwnership,
+}
+
+impl Brc721Flag {
+	pub(crate) fn to_byte_slice(self) -> [u8; 1] {
+		[self as u8]
+	}
+}
+
+/// The size of a brc721 flag in bytes
+pub(crate) const BRC721_FLAG_LENGTH: usize = 1;

--- a/crates/ordinals/src/brc721/operations.rs
+++ b/crates/ordinals/src/brc721/operations.rs
@@ -8,10 +8,10 @@ pub(crate) const BRC721_INIT_CODE: opcodes::Opcode = opcodes::all::OP_PUSHNUM_15
 /// error otherwise.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum Brc721Operation {
-	RegisterCollection,
+	RegisterCollection = 0,
 	// TODO: Remove this attribute as soon as register ownership flow is introduced
 	#[allow(dead_code)]
-	RegisterOwnership,
+	RegisterOwnership = 1,
 }
 
 impl Brc721Operation {

--- a/crates/ordinals/src/brc721/operations.rs
+++ b/crates/ordinals/src/brc721/operations.rs
@@ -7,6 +7,7 @@ pub(crate) const BRC721_INIT_CODE: opcodes::Opcode = opcodes::all::OP_PUSHNUM_15
 /// numerical byte of each operation. Only fieldless variants are allowed, leading to a compile
 /// error otherwise.
 #[derive(Debug, Clone, PartialEq)]
+#[repr(u8)]
 pub(crate) enum Brc721Operation {
 	RegisterCollection = 0,
 	// TODO: Remove this attribute as soon as register ownership flow is introduced

--- a/crates/ordinals/src/brc721/operations.rs
+++ b/crates/ordinals/src/brc721/operations.rs
@@ -15,7 +15,7 @@ pub(crate) enum Brc721Operation {
 }
 
 impl Brc721Operation {
-	pub(crate) fn byte_slice(self) -> [u8; BRC721_FLAG_LENGTH] {
+	pub(crate) fn byte_slice(self) -> [u8; BRC721_OPERATION_LENGTH] {
 		[self as u8]
 	}
 }

--- a/crates/ordinals/src/brc721/register_collection.rs
+++ b/crates/ordinals/src/brc721/register_collection.rs
@@ -27,8 +27,8 @@ pub struct RegisterCollection {
 impl RegisterCollection {
 	/// Encodes a `RegisterCollection` instance into a Bitcoin script.
 	///
-	/// The encoded script includes an OP_RETURN opcode, the BRC721_INIT_CODE,
-	/// the collection address, and the rebaseable flag.
+	/// The encoded script includes an OP_RETURN opcode, the BRC721_INIT_CODE, the register
+	/// collection flag, the collection address, and the rebaseable flag.
 	pub fn to_script(&self) -> ScriptBuf {
 		let address = self.address.as_fixed_bytes();
 		let rebaseable = [self.rebaseable as u8];
@@ -44,8 +44,8 @@ impl RegisterCollection {
 
 	/// Decodes a Bitcoin script into a `RegisterCollection` instance.
 	///
-	/// The function checks for the presence of OP_RETURN, BRC721_INIT_CODE,
-	/// a 20-byte collection address, and a 1-byte rebaseable flag in the script.
+	/// The function checks for the presence of OP_RETURN, BRC721_INIT_CODE, the register collection
+	/// flag, a 20-byte collection address, and a 1-byte rebaseable flag in the script.
 	pub fn from_script(script: &ScriptBuf) -> Result<Self, RegisterCollectionError> {
 		let mut instructions = script.instructions();
 

--- a/crates/ordinals/src/brc721/register_collection.rs
+++ b/crates/ordinals/src/brc721/register_collection.rs
@@ -36,7 +36,7 @@ impl RegisterCollection {
 		script::Builder::new()
 			.push_opcode(opcodes::all::OP_RETURN)
 			.push_opcode(BRC721_INIT_CODE)
-			.push_slice(&Brc721Flag::RegisterCollection.to_byte_slice())
+			.push_slice(Brc721Flag::RegisterCollection.byte_slice())
 			.push_slice(address)
 			.push_slice(rebaseable)
 			.into_script()
@@ -53,7 +53,7 @@ impl RegisterCollection {
 		expect_opcode(&mut instructions, BRC721_INIT_CODE, "BRC721_INIT_CODE")?;
 
 		match expect_push_bytes(&mut instructions, BRC721_FLAG_LENGTH, "Register collection flag") {
-			Ok(byte) if &byte == &Brc721Flag::RegisterCollection.to_byte_slice() => (),
+			Ok(byte) if byte == Brc721Flag::RegisterCollection.byte_slice() => (),
 			_ => return Err(RegisterCollectionError::UnexpectedInstruction),
 		}
 

--- a/crates/ordinals/src/brc721/register_collection.rs
+++ b/crates/ordinals/src/brc721/register_collection.rs
@@ -1,4 +1,4 @@
-use crate::brc721::flags::{Brc721Operation, BRC721_FLAG_LENGTH, BRC721_INIT_CODE};
+use crate::brc721::operations::{Brc721Operation, BRC721_INIT_CODE, BRC721_OPERATION_LENGTH};
 use bitcoin::{
 	opcodes,
 	script::{self, Instruction},
@@ -52,7 +52,11 @@ impl RegisterCollection {
 		expect_opcode(&mut instructions, opcodes::all::OP_RETURN, "OP_RETURN")?;
 		expect_opcode(&mut instructions, BRC721_INIT_CODE, "BRC721_INIT_CODE")?;
 
-		match expect_push_bytes(&mut instructions, BRC721_FLAG_LENGTH, "Register collection flag") {
+		match expect_push_bytes(
+			&mut instructions,
+			BRC721_OPERATION_LENGTH,
+			"Register collection operation identifier",
+		) {
 			Ok(byte) if byte == Brc721Operation::RegisterCollection.byte_slice() => (),
 			Err(err) => return Err(err),
 			_ => return Err(RegisterCollectionError::UnexpectedInstruction),
@@ -244,7 +248,9 @@ mod tests {
 		let result = RegisterCollection::from_script(&script);
 		assert_eq!(
 			result.unwrap_err(),
-			RegisterCollectionError::InstructionNotFound("Register collection operation".to_string())
+			RegisterCollectionError::InstructionNotFound(
+				"Register collection operation identifier".to_string()
+			)
 		);
 	}
 

--- a/crates/ordinals/src/brc721/register_collection.rs
+++ b/crates/ordinals/src/brc721/register_collection.rs
@@ -235,7 +235,7 @@ mod tests {
 	}
 
 	#[test]
-	fn register_collection_decode_missing_register_collection_flag_returns_error() {
+	fn register_collection_decode_missing_register_collection_operation_returns_error() {
 		let script = script::Builder::new()
 			.push_opcode(opcodes::all::OP_RETURN)
 			.push_opcode(BRC721_INIT_CODE)

--- a/crates/ordinals/src/brc721/register_collection.rs
+++ b/crates/ordinals/src/brc721/register_collection.rs
@@ -249,7 +249,7 @@ mod tests {
 	}
 
 	#[test]
-	fn register_collection_decode_wrong_flag_returns_error() {
+	fn register_collection_decode_wrong_operation_returns_error() {
 		let script = script::Builder::new()
 			.push_opcode(opcodes::all::OP_RETURN)
 			.push_opcode(BRC721_INIT_CODE)

--- a/crates/ordinals/src/brc721/register_collection.rs
+++ b/crates/ordinals/src/brc721/register_collection.rs
@@ -244,7 +244,7 @@ mod tests {
 		let result = RegisterCollection::from_script(&script);
 		assert_eq!(
 			result.unwrap_err(),
-			RegisterCollectionError::InstructionNotFound("Register collection flag".to_string())
+			RegisterCollectionError::InstructionNotFound("Register collection operation".to_string())
 		);
 	}
 

--- a/crates/ordinals/src/brc721/register_collection.rs
+++ b/crates/ordinals/src/brc721/register_collection.rs
@@ -1,4 +1,4 @@
-use crate::brc721::flags::{Brc721Flag, BRC721_FLAG_LENGTH, BRC721_INIT_CODE};
+use crate::brc721::flags::{Brc721Operation, BRC721_FLAG_LENGTH, BRC721_INIT_CODE};
 use bitcoin::{
 	opcodes,
 	script::{self, Instruction},
@@ -36,7 +36,7 @@ impl RegisterCollection {
 		script::Builder::new()
 			.push_opcode(opcodes::all::OP_RETURN)
 			.push_opcode(BRC721_INIT_CODE)
-			.push_slice(Brc721Flag::RegisterCollection.byte_slice())
+			.push_slice(Brc721Operation::RegisterCollection.byte_slice())
 			.push_slice(address)
 			.push_slice(rebaseable)
 			.into_script()
@@ -53,7 +53,7 @@ impl RegisterCollection {
 		expect_opcode(&mut instructions, BRC721_INIT_CODE, "BRC721_INIT_CODE")?;
 
 		match expect_push_bytes(&mut instructions, BRC721_FLAG_LENGTH, "Register collection flag") {
-			Ok(byte) if byte == Brc721Flag::RegisterCollection.byte_slice() => (),
+			Ok(byte) if byte == Brc721Operation::RegisterCollection.byte_slice() => (),
 			Err(err) => return Err(err),
 			_ => return Err(RegisterCollectionError::UnexpectedInstruction),
 		}
@@ -253,7 +253,7 @@ mod tests {
 		let script = script::Builder::new()
 			.push_opcode(opcodes::all::OP_RETURN)
 			.push_opcode(BRC721_INIT_CODE)
-			.push_slice(Brc721Flag::RegisterOwnership.byte_slice())
+			.push_slice(Brc721Operation::RegisterOwnership.byte_slice())
 			.into_script();
 
 		let result = RegisterCollection::from_script(&script);
@@ -265,7 +265,7 @@ mod tests {
 		let script = script::Builder::new()
 			.push_opcode(opcodes::all::OP_RETURN)
 			.push_opcode(BRC721_INIT_CODE)
-			.push_slice(Brc721Flag::RegisterCollection.byte_slice())
+			.push_slice(Brc721Operation::RegisterCollection.byte_slice())
 			.into_script();
 
 		let result = RegisterCollection::from_script(&script);
@@ -281,7 +281,7 @@ mod tests {
 		let script = script::Builder::new()
 			.push_opcode(opcodes::all::OP_RETURN)
 			.push_opcode(BRC721_INIT_CODE)
-			.push_slice(Brc721Flag::RegisterCollection.byte_slice())
+			.push_slice(Brc721Operation::RegisterCollection.byte_slice())
 			.push_slice::<&script::PushBytes>((&address).into())
 			.into_script();
 
@@ -298,7 +298,7 @@ mod tests {
 		let script = script::Builder::new()
 			.push_opcode(opcodes::all::OP_RETURN)
 			.push_opcode(BRC721_INIT_CODE)
-			.push_slice(Brc721Flag::RegisterCollection.byte_slice())
+			.push_slice(Brc721Operation::RegisterCollection.byte_slice())
 			.push_slice::<&script::PushBytes>((&address).into())
 			.into_script();
 
@@ -315,7 +315,7 @@ mod tests {
 		let script = script::Builder::new()
 			.push_opcode(opcodes::all::OP_RETURN)
 			.push_opcode(BRC721_INIT_CODE)
-			.push_slice(Brc721Flag::RegisterCollection.byte_slice())
+			.push_slice(Brc721Operation::RegisterCollection.byte_slice())
 			.push_slice::<&script::PushBytes>((&address).into())
 			.into_script();
 
@@ -333,7 +333,7 @@ mod tests {
 		let script = script::Builder::new()
 			.push_opcode(opcodes::all::OP_RETURN)
 			.push_opcode(BRC721_INIT_CODE)
-			.push_slice(Brc721Flag::RegisterCollection.byte_slice())
+			.push_slice(Brc721Operation::RegisterCollection.byte_slice())
 			.push_slice::<&script::PushBytes>((&address).into())
 			.push_slice::<&script::PushBytes>((&rebaseable).into())
 			.into_script();
@@ -351,7 +351,7 @@ mod tests {
 		let script = script::Builder::new()
 			.push_opcode(opcodes::all::OP_RETURN)
 			.push_opcode(BRC721_INIT_CODE)
-			.push_slice(Brc721Flag::RegisterCollection.byte_slice())
+			.push_slice(Brc721Operation::RegisterCollection.byte_slice())
 			.push_slice::<&script::PushBytes>((&address).into())
 			.push_slice::<&script::PushBytes>((&rebaseable).into())
 			.push_slice::<&script::PushBytes>((&extra_data).into())


### PR DESCRIPTION
This PR prepare the BRC721 module to operate under the `OP_15` opcode in all operations, adding an extra byte that will be used to identify the needed brc721 operation